### PR TITLE
TypeHint: Fix for `List` type hint to `list`

### DIFF
--- a/monkeytoolbox/code_utils.py
+++ b/monkeytoolbox/code_utils.py
@@ -4,7 +4,7 @@ import random
 import secrets
 import string
 from threading import Event, Thread
-from typing import Any, Callable, Iterable, List, MutableMapping, Optional, TypeVar
+from typing import Any, Callable, Iterable, MutableMapping, Optional, TypeVar
 
 T = TypeVar("T")
 
@@ -26,7 +26,7 @@ def apply_filters(filters: Iterable[Callable[[T], bool]], iterable: Iterable[T])
     return filtered_iterable
 
 
-def queue_to_list(q: queue.Queue) -> List[Any]:
+def queue_to_list(q: queue.Queue) -> list[Any]:
     list_ = []
     try:
         while True:

--- a/monkeytoolbox/network_utils.py
+++ b/monkeytoolbox/network_utils.py
@@ -1,6 +1,6 @@
 import ipaddress
 from ipaddress import IPv4Address, IPv4Interface
-from typing import Iterable, List, Optional, Sequence
+from typing import Iterable, Optional, Sequence
 
 import ifaddr
 import psutil
@@ -10,7 +10,7 @@ def get_my_ip_addresses() -> Sequence[IPv4Address]:
     return [interface.ip for interface in get_network_interfaces()]
 
 
-def get_network_interfaces() -> List[IPv4Interface]:
+def get_network_interfaces() -> list[IPv4Interface]:
     local_interfaces = []
     for adapter in ifaddr.get_adapters():
         for ip in _select_ipv4_ips(adapter.ips):
@@ -41,7 +41,7 @@ def port_is_used(
 def get_connections(
     ports: Optional[Sequence[int]] = None,
     ip_addresses: Optional[Sequence[IPv4Address]] = None,
-) -> List[psutil._common.sconn]:
+) -> list[psutil._common.sconn]:
     connections = psutil.net_connections()
     if ports:
         connections = [connection for connection in connections if connection.laddr.port in ports]


### PR DESCRIPTION
Changed List type hint to list in :

1. monkeytoolbox\network_utils.py
2. monkeytoolbox\code_utils.py

All the test cases passed for the changes made.

![image](https://github.com/guardicode/monkeytoolbox/assets/68015525/620ef0e7-2e7a-4e9d-8441-da84b25e3a05)
